### PR TITLE
Update Camera to Track Player

### DIFF
--- a/Project2/src/Engine/Simulation/Character/BaseCharacter.cs
+++ b/Project2/src/Engine/Simulation/Character/BaseCharacter.cs
@@ -24,5 +24,10 @@ namespace Project2.src.Engine.Simulation.Character
         {
             position = new Vector2(position.X + speed.X, position.Y + speed.Y);
         }
+
+        public bool isPlayerMoving()
+        {
+            return (speed.X != 0 || speed.Y != 0);
+        }
     }
 }

--- a/Project2/src/Engine/Simulation/World/Camera.cs
+++ b/Project2/src/Engine/Simulation/World/Camera.cs
@@ -129,7 +129,7 @@ namespace Project2.src.Engine.Simulation.World
                 cameraMovement.Y = -moveSpeed;
             }
 
-            if (GlobalParameters.GlobalKeyboard.GetPress("ARROW_DOWN") || getMouseScreenPosition().Y >= 1077)
+            if (GlobalParameters.GlobalKeyboard.GetPress("ARROW_DOWN") || getMouseScreenPosition().Y >= GlobalParameters.screenHeight)
             {
                 cameraMovement.Y = moveSpeed;
             }
@@ -139,7 +139,7 @@ namespace Project2.src.Engine.Simulation.World
                 cameraMovement.X = -moveSpeed;
             }
 
-            if (GlobalParameters.GlobalKeyboard.GetPress("ARROW_RIGHT") || getMouseScreenPosition().X >= 1917)
+            if (GlobalParameters.GlobalKeyboard.GetPress("ARROW_RIGHT") || getMouseScreenPosition().X >= GlobalParameters.screenWidth)
             {
                 cameraMovement.X = moveSpeed;
             }

--- a/Project2/src/Engine/Simulation/World/Camera.cs
+++ b/Project2/src/Engine/Simulation/World/Camera.cs
@@ -75,10 +75,18 @@ namespace Project2.src.Engine.Simulation.World
 
         public void UpdateCamera(Viewport bounds)
         {
+            // Track the player
+            if (GameSettings.player.isPlayerMoving())
+            {
+                Position = new Vector2(GameSettings.player.position.X, GameSettings.player.position.Y);
+            }
+
+            // Make sure the camera can't be moved off the world
             if (Position.X * 2 - bounds.Width < 0)
                 Position = new Vector2(bounds.Width / 2, Position.Y);
             if (Position.Y * 2 - Bounds.Height < 0)
                 Position = new Vector2(Position.X, bounds.Height / 2);
+
             if (Position.X + bounds.Width / 2 > GlobalParameters.Game.world.TILE_WIDTH * GlobalParameters.Game.world.WORLD_WIDTH)
             {
                 Position = new Vector2(
@@ -115,6 +123,7 @@ namespace Project2.src.Engine.Simulation.World
                 moveSpeed = 10;
             }
 
+            // Handle manual camera movement
             if (GlobalParameters.GlobalKeyboard.GetPress("ARROW_UP") || getMouseScreenPosition().Y <= 3)
             {
                 cameraMovement.Y = -moveSpeed;
@@ -135,6 +144,7 @@ namespace Project2.src.Engine.Simulation.World
                 cameraMovement.X = moveSpeed;
             }
 
+            // Handle zoom
             previousMouseWheelValue = currentMouseWheelValue;
             currentMouseWheelValue = Mouse.GetState().ScrollWheelValue;
 


### PR DESCRIPTION
Implements #3

**DESCRIPTION**
Updates the camera to track the player when they move. If they are not moving, you can use the arrow keys or mouse to move around the camera, however moving your player from that point will reset the camera to the player location

In the future we will want to have more smooth movement using a bounding box that the player must remain inside. We also might want to incorporate a toggle for if tracking the player is active or not